### PR TITLE
gradle-7x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     `maven-publish`
     signing
 
-    id("org.jetbrains.kotlin.jvm") version "1.4.31"
+    id("org.jetbrains.kotlin.jvm") version "1.5.0"
     id("nebula.maven-resolved-dependencies") version "17.3.2"
     id("nebula.release") version "15.3.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("nebula.release") version "15.3.1"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 
-    id("com.github.hierynomus.license") version "0.15.0"
+    id("com.github.hierynomus.license") version "0.16.1"
     id("com.github.jk1.dependency-license-report") version "1.16"
 
     id("nebula.maven-publish") version "17.3.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,1 @@
 rootProject.name = "rewrite-kubernetes"
-
-enableFeaturePreview("VERSION_ORDERING_V2")


### PR DESCRIPTION
https://docs.gradle.org/7.0.1/release-notes.html

VERSION_ORDERING_V2 is now the default (https://github.com/gradle/gradle/blob/7286dcd1d9b46297fd62231cc7fbf17d958604aa/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java#L31)

>https://docs.gradle.org/6.5-rc-1/release-notes.html
>enableFeaturePreview("VERSION_ORDERING_V2")
>This ordering will be enabled by default in Gradle 7.0.
>https://github.com/gradle/gradle/issues/ - 15722
>