### PR TITLE
Recipe to find and cap resource values that exceed a max

### DIFF
--- a/src/main/java/org/openrewrite/kubernetes/CapResourceValueToMaximum.java
+++ b/src/main/java/org/openrewrite/kubernetes/CapResourceValueToMaximum.java
@@ -1,0 +1,53 @@
+package org.openrewrite.kubernetes;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.kubernetes.util.ResourceValue;
+import org.openrewrite.yaml.MergeValueVisitor;
+import org.openrewrite.yaml.XPathMatcher;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class CapResourceValueToMaximum extends Recipe {
+
+    @Option(displayName = "Resource value type",
+            description = "The type of resource to search for.",
+            example = "limits")
+    String resourceValueType;
+    @Option(displayName = "Resource type",
+            description = "The type of resource value to search for.",
+            example = "memory")
+    String resourceType;
+    @Option(displayName = "Resource limit",
+            description = "The resource maximum to search for to find resources that request more than the maximum.",
+            example = "2Gi")
+    String resourceLimit;
+
+    @Override
+    public String getDisplayName() {
+        return "Cap exceeds resource value";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Cap resource values that exceed a specific maximum.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        ResourceValue max = ResourceValue.parseResourceString(resourceLimit);
+
+        return new MergeValueVisitor<>(
+                "spec/containers/resources/" + resourceValueType + "/" + resourceType,
+                new ExceedsResourceValue(max),
+                (s, ctx) -> {
+                    ResourceValue rv = ResourceValue.parseResourceString(s.getValue());
+                    return s.withValue(max.convertTo(rv.getUnit()).toString());
+                });
+    }
+
+}

--- a/src/main/java/org/openrewrite/kubernetes/CapResourceValueToMaximum.java
+++ b/src/main/java/org/openrewrite/kubernetes/CapResourceValueToMaximum.java
@@ -16,7 +16,8 @@ public class CapResourceValueToMaximum extends Recipe {
 
     @Option(displayName = "Resource value type",
             description = "The type of resource to search for.",
-            example = "limits")
+            example = "limits",
+            valid = {"limits", "requests"})
     String resourceValueType;
     @Option(displayName = "Resource type",
             description = "The type of resource value to search for.",

--- a/src/main/java/org/openrewrite/kubernetes/ExceedsResourceValue.java
+++ b/src/main/java/org/openrewrite/kubernetes/ExceedsResourceValue.java
@@ -1,0 +1,19 @@
+package org.openrewrite.kubernetes;
+
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.kubernetes.util.ResourceValue;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.function.BiPredicate;
+
+@Value
+public class ExceedsResourceValue implements BiPredicate<Yaml.Scalar, ExecutionContext> {
+    ResourceValue maximum;
+
+    @Override
+    public boolean test(Yaml.Scalar scalar, ExecutionContext executionContext) {
+        ResourceValue rv = ResourceValue.parseResourceString(scalar.getValue());
+        return rv.getAbsoluteValue() > maximum.getAbsoluteValue();
+    }
+}

--- a/src/main/java/org/openrewrite/kubernetes/search/FindExceedsResourceValue.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindExceedsResourceValue.java
@@ -1,0 +1,51 @@
+package org.openrewrite.kubernetes.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.kubernetes.ExceedsResourceValue;
+import org.openrewrite.kubernetes.util.ResourceValue;
+import org.openrewrite.yaml.MergeValueVisitor;
+import org.openrewrite.yaml.search.YamlSearchResult;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindExceedsResourceValue extends Recipe {
+
+    @Option(displayName = "Resource value type",
+            description = "The type of resource value to search for.",
+            example = "limits",
+            valid = {"limits", "requests"})
+    String resourceValueType;
+    @Option(displayName = "Resource limit type",
+            description = "The type of resource limit to search for.",
+            example = "memory")
+    String resourceType;
+    @Option(displayName = "Resource limit",
+            description = "The resource limit maximum to search for to find resources that request more than the maximum.",
+            example = "2Gi")
+    String resourceLimit;
+
+    @Override
+    public String getDisplayName() {
+        return "Find exceeds resource limit";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find resource manifests that have limits set beyond a specific maximum.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        ResourceValue max = ResourceValue.parseResourceString(resourceLimit);
+
+        return new MergeValueVisitor<>(
+                "spec/containers/resources/" + resourceValueType + "/" + resourceType,
+                new ExceedsResourceValue(max),
+                (s, ctx) -> s.withMarkers(s.getMarkers().addIfAbsent(new YamlSearchResult(Tree.randomId(),
+                        FindExceedsResourceValue.this,
+                        "exceeds maximum of " + max))));
+    }
+
+}

--- a/src/main/java/org/openrewrite/kubernetes/util/ResourceValue.java
+++ b/src/main/java/org/openrewrite/kubernetes/util/ResourceValue.java
@@ -1,0 +1,147 @@
+package org.openrewrite.kubernetes.util;
+
+import lombok.EqualsAndHashCode;
+
+import java.util.Locale;
+
+@EqualsAndHashCode
+public class ResourceValue {
+
+    public enum Unit {
+        K,
+        M,
+        G,
+        T,
+        P,
+        Ki,
+        Mi,
+        Gi,
+        Ti,
+        Pi;
+
+        @Override
+        public String toString() {
+            return this == K ? "k" : super.toString();
+        }
+
+        public static Unit fromString(String s) {
+            switch (s.toLowerCase(Locale.ROOT)) {
+                case "k":
+                    return K;
+                case "m":
+                    return M;
+                case "g":
+                    return G;
+                case "t":
+                    return T;
+                case "p":
+                    return P;
+                case "ki":
+                    return Ki;
+                case "mi":
+                    return Mi;
+                case "gi":
+                    return Gi;
+                case "ti":
+                    return Ti;
+                case "pi":
+                    return Pi;
+                default:
+                    return M;
+            }
+        }
+
+        public long fromAbsoluteValue(long absoluteValue) {
+            switch (this) {
+                case M:
+                    return (long) (absoluteValue / Math.pow(1000, 2));
+                case G:
+                    return (long) (absoluteValue / Math.pow(1000, 3));
+                case T:
+                    return (long) (absoluteValue / Math.pow(1000, 4));
+                case P:
+                    return (long) (absoluteValue / Math.pow(1000, 5));
+                case Ki:
+                    return absoluteValue / 1024;
+                case Mi:
+                    return (long) (absoluteValue / Math.pow(1024, 2));
+                case Gi:
+                    return (long) (absoluteValue / Math.pow(1024, 3));
+                case Ti:
+                    return (long) (absoluteValue / Math.pow(1024, 4));
+                case Pi:
+                    return (long) (absoluteValue / Math.pow(1024, 5));
+                default:
+                    return absoluteValue / 1000;
+            }
+        }
+
+        public long toAbsoluteValue(long relativeValue) {
+            switch (this) {
+                case M:
+                    return (long) (relativeValue * Math.pow(1000, 2));
+                case G:
+                    return (long) (relativeValue * Math.pow(1000, 3));
+                case T:
+                    return (long) (relativeValue * Math.pow(1000, 4));
+                case P:
+                    return (long) (relativeValue * Math.pow(1000, 5));
+                case Ki:
+                    return relativeValue * 1024;
+                case Mi:
+                    return (long) (relativeValue * Math.pow(1024, 2));
+                case Gi:
+                    return (long) (relativeValue * Math.pow(1024, 3));
+                case Ti:
+                    return (long) (relativeValue * Math.pow(1024, 4));
+                case Pi:
+                    return (long) (relativeValue * Math.pow(1024, 5));
+                default:
+                    return relativeValue * 1000;
+            }
+        }
+    }
+
+    private final long value;
+    private final Unit unit;
+
+    private ResourceValue(long value, Unit unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    private ResourceValue(String value, Unit unit) {
+        this(unit.toAbsoluteValue(Long.parseLong(value)), unit);
+    }
+
+    public static ResourceValue parseResourceString(String s) {
+        String val;
+        Unit unit;
+        int unitLen = 1;
+        if (s.endsWith("i")) {
+            unitLen = 2;
+        }
+
+        val = s.substring(0, s.length() - unitLen);
+        unit = Unit.fromString(s.substring(s.length() - unitLen));
+        return new ResourceValue(val, unit);
+    }
+
+    public long getAbsoluteValue() {
+        return value;
+    }
+
+    public ResourceValue convertTo(Unit destUnit) {
+        return new ResourceValue(value, destUnit);
+    }
+
+    public Unit getUnit() {
+        return unit;
+    }
+
+    @Override
+    public String toString() {
+        return unit.fromAbsoluteValue(value) + unit.toString();
+    }
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/CapResourceValueToMaximumTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/CapResourceValueToMaximumTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kubernetes
+
+import org.junit.jupiter.api.Test
+
+class CapResourceValueToMaximumTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must cap resource limit to given maximum in different units`() = assertChanged(
+        recipe = CapResourceValueToMaximum(
+            "limits",
+            "memory",
+            "64Mi"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    limits:
+                        cpu: "500Mi"
+                        memory: "256M"
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    limits:
+                        cpu: "500Mi"
+                        memory: "67M"
+        """
+    )
+    @Test
+    fun `must cap resource requests to given maximum in different units`() = assertChanged(
+        recipe = CapResourceValueToMaximum(
+            "requests",
+            "cpu",
+            "100Mi"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    requests:
+                        cpu: "500Mi"
+                        memory: "256M"
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    requests:
+                        cpu: "100Mi"
+                        memory: "256M"
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/KubernetesRecipeTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/KubernetesRecipeTest.kt
@@ -31,9 +31,9 @@ interface KubernetesRecipeTest : RecipeTest<Kubernetes> {
     fun assertChanged(
         parser: KubernetesParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        @Language("xml") before: String,
-        @Language("xml") dependsOn: Array<String> = emptyArray(),
-        @Language("xml") after: String,
+        @Language("yml") before: String,
+        @Language("yml") dependsOn: Array<String> = emptyArray(),
+        @Language("yml") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Kubernetes) -> Unit = { }
@@ -44,9 +44,9 @@ interface KubernetesRecipeTest : RecipeTest<Kubernetes> {
     fun assertChanged(
         parser: KubernetesParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        @Language("xml") before: File,
-        @Language("xml") dependsOn: Array<File> = emptyArray(),
-        @Language("xml") after: String,
+        @Language("yml") before: File,
+        @Language("yml") dependsOn: Array<File> = emptyArray(),
+        @Language("yml") after: String,
         cycles: Int = 2,
         expectedCyclesThatMakeChanges: Int = cycles - 1,
         afterConditions: (Kubernetes) -> Unit = { }
@@ -57,8 +57,8 @@ interface KubernetesRecipeTest : RecipeTest<Kubernetes> {
     fun assertUnchanged(
         parser: KubernetesParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        @Language("xml") before: String,
-        @Language("xml") dependsOn: Array<String> = emptyArray()
+        @Language("yml") before: String,
+        @Language("yml") dependsOn: Array<String> = emptyArray()
     ) {
         super.assertUnchangedBase(parser, recipe, before, dependsOn)
     }
@@ -66,8 +66,8 @@ interface KubernetesRecipeTest : RecipeTest<Kubernetes> {
     fun assertUnchanged(
         parser: KubernetesParser = this.parser,
         recipe: Recipe = this.recipe!!,
-        @Language("xml") before: File,
-        @Language("xml") dependsOn: Array<File> = emptyArray()
+        @Language("yml") before: File,
+        @Language("yml") dependsOn: Array<File> = emptyArray()
     ) {
         super.assertUnchangedBase(parser, recipe, before, dependsOn)
     }

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindExceedsResourceValueTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindExceedsResourceValueTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kubernetes.search
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.kubernetes.KubernetesRecipeTest
+
+class FindExceedsResourceValueTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must find limits that exceed a given maximum`() = assertChanged(
+        recipe = FindExceedsResourceValue(
+            "limits",
+            "memory",
+            "64m"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    limits:
+                        cpu: "500Mi"
+                        memory: "256m"
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    limits:
+                        cpu: "500Mi"
+                        memory: ~~(exceeds maximum of 64M)~~>"256m"
+        """
+    )
+
+    @Test
+    fun `must convert limits in different units`() = assertChanged(
+        recipe = FindExceedsResourceValue(
+            "limits",
+            "memory",
+            "1Gi"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    limits:
+                        cpu: "500Mi"
+                        memory: "2000M"
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    limits:
+                        cpu: "500Mi"
+                        memory: ~~(exceeds maximum of 1Gi)~~>"2000M"
+        """
+    )
+
+    @Test
+    fun `must find requests that exceed a given maximum`() = assertChanged(
+        recipe = FindExceedsResourceValue(
+            "requests",
+            "cpu",
+            "100m"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    requests:
+                        cpu: "500Mi"
+                        memory: "256m"
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    requests:
+                        cpu: ~~(exceeds maximum of 100M)~~>"500Mi"
+                        memory: "256m"
+        """
+    )
+
+    @Test
+    fun `must convert requests in different units`() = assertChanged(
+        recipe = FindExceedsResourceValue(
+            "requests",
+            "memory",
+            "1Gi"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    requests:
+                        cpu: "500Mi"
+                        memory: "2000M"
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              labels:
+                app: application
+            spec:
+              containers:            
+              - image: nginx:latest
+                resources:
+                    requests:
+                        cpu: "500Mi"
+                        memory: ~~(exceeds maximum of 1Gi)~~>"2000M"
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/util/ResourceValueTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/util/ResourceValueTest.kt
@@ -1,0 +1,36 @@
+package org.openrewrite.kubernetes.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class ResourceValueTest {
+
+    @ParameterizedTest
+    @MethodSource("resourceUnits")
+    fun `given a base unit, must parse into ResourceValue`(unit: ResourceValue.Unit) =
+        setOf(10L, 100L, 1000L).forEach { i ->
+            val value = ResourceValue.parseResourceString("$i$unit")
+            assertThat(value.unit).isEqualTo(unit)
+            assertThat(unit.fromAbsoluteValue(value.absoluteValue)).isEqualTo(i)
+        }
+
+    private companion object {
+        @JvmStatic
+        fun resourceUnits() = Stream.of(
+            Arguments.of(ResourceValue.Unit.K),
+            Arguments.of(ResourceValue.Unit.M),
+            Arguments.of(ResourceValue.Unit.G),
+            Arguments.of(ResourceValue.Unit.T),
+            Arguments.of(ResourceValue.Unit.P),
+            Arguments.of(ResourceValue.Unit.Ki),
+            Arguments.of(ResourceValue.Unit.Mi),
+            Arguments.of(ResourceValue.Unit.Gi),
+            Arguments.of(ResourceValue.Unit.Ti),
+            Arguments.of(ResourceValue.Unit.Pi),
+        )
+    }
+
+}


### PR DESCRIPTION
This change includes two recipes: 1 to find resource values (either `limits` or `requests`) which exceed a given maximum and 1 to cap values that exceed the maximum down to the max. 

The units in the original will be preserved, even if the unit specified in the `resourceLimit` is of a different type (`Gi` instead of `M`).

Depends on the helper in PR https://github.com/openrewrite/rewrite/pull/736 