### PR TITLE
Find usage of disallowed tags in containers and initContainers

### DIFF
--- a/src/main/java/org/openrewrite/kubernetes/ContainerImage.java
+++ b/src/main/java/org/openrewrite/kubernetes/ContainerImage.java
@@ -1,0 +1,71 @@
+package org.openrewrite.kubernetes;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.yaml.tree.Yaml;
+
+import static org.openrewrite.internal.StringUtils.isNullOrEmpty;
+
+@Value
+@EqualsAndHashCode
+public class ContainerImage {
+
+    ImageName imageName;
+
+    public ContainerImage(Yaml.Scalar scalar) {
+        this(scalar.getValue());
+    }
+
+    public ContainerImage(String imageName) {
+        String repository = null;
+        String image = imageName;
+        String tag = null;
+        String digest = null;
+
+        int idx = imageName.lastIndexOf('@');
+        if (idx > -1) {
+            digest = imageName.substring(idx + 1);
+            imageName = imageName.substring(0, idx);
+        }
+        idx = imageName.lastIndexOf(':');
+        if (idx > -1) {
+            tag = imageName.substring(idx + 1);
+            imageName = imageName.substring(0, idx);
+        }
+        idx = imageName.lastIndexOf('/');
+        if (idx > -1) {
+            image = imageName.substring(idx + 1);
+            String s = imageName.substring(0, idx);
+            if (!isNullOrEmpty(s)) {
+                repository = s;
+            }
+        }
+        this.imageName = new ImageName(repository, image, tag, digest);
+    }
+
+    @Value
+    public static class ImageName {
+
+        String repository;
+        String image;
+        String tag;
+        String digest;
+
+        @Override
+        public String toString() {
+            String s = "";
+            if (!isNullOrEmpty(repository)) {
+                s += repository + "/";
+            }
+            s += image;
+            if (!isNullOrEmpty(tag)) {
+                s += ":" + tag;
+            }
+            if (!isNullOrEmpty(digest)) {
+                s += "@" + digest;
+            }
+            return s;
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/kubernetes/ContainerImage.java
+++ b/src/main/java/org/openrewrite/kubernetes/ContainerImage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.kubernetes;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
@@ -1,0 +1,56 @@
+package org.openrewrite.kubernetes.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.kubernetes.ContainerImage;
+import org.openrewrite.yaml.XPathMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.search.YamlSearchResult;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Set;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindDisallowedImageTags extends Recipe {
+
+    @Option(displayName = "Disallowed tags",
+            description = "The set of image tags to find which are considered disallowed.",
+            example = "latest")
+    Set<String> disallowedTags;
+
+    @Override
+    public String getDisplayName() {
+        return "Disallowed tags";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The set of image tags to find which are considered disallowed.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        XPathMatcher imageMatcher = new XPathMatcher("//spec/containers/image");
+        XPathMatcher initImageMatcher = new XPathMatcher("//spec/initContainers/image");
+
+        return new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Scalar visitScalar(Yaml.Scalar scalar, ExecutionContext executionContext) {
+                Cursor parent = getCursor().getParentOrThrow();
+                if (imageMatcher.matches(parent) || initImageMatcher.matches(parent)) {
+                    ContainerImage image = new ContainerImage(scalar);
+                    if (disallowedTags.stream().anyMatch(t -> t.equals(image.getImageName().getTag()))) {
+                        return scalar.withMarkers(scalar.getMarkers().addIfAbsent(new YamlSearchResult(
+                                FindDisallowedImageTags.this,
+                                "disallowed tag: " + disallowedTags
+                        )));
+                    }
+                }
+                return super.visitScalar(scalar, executionContext);
+            }
+        };
+    }
+
+}

--- a/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.kubernetes.search;
 
 import lombok.EqualsAndHashCode;

--- a/src/test/kotlin/org/openrewrite/kubernetes/ContainerImageTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/ContainerImageTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.kubernetes
 
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/org/openrewrite/kubernetes/ContainerImageTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/ContainerImageTest.kt
@@ -1,0 +1,52 @@
+package org.openrewrite.kubernetes
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ContainerImageTest {
+
+    @Test
+    fun `must parse full container image name`() {
+        val s = "repo.io/account/bucket/image:v1.2.3@digest"
+
+        val image = ContainerImage(s)
+        assertThat(image.imageName.repository).isEqualTo("repo.io/account/bucket")
+        assertThat(image.imageName.image).isEqualTo("image")
+        assertThat(image.imageName.tag).isEqualTo("v1.2.3")
+        assertThat(image.imageName.digest).isEqualTo("digest")
+    }
+
+    @Test
+    fun `must parse partial container image name`() {
+        val s = "bucket/image:latest"
+
+        val image = ContainerImage(s)
+        assertThat(image.imageName.repository).isEqualTo("bucket")
+        assertThat(image.imageName.image).isEqualTo("image")
+        assertThat(image.imageName.tag).isEqualTo("latest")
+        assertThat(image.imageName.digest).isNullOrEmpty()
+    }
+
+    @Test
+    fun `must parse only container image name`() {
+        val s = "image"
+
+        val image = ContainerImage(s)
+        assertThat(image.imageName.repository).isNullOrEmpty()
+        assertThat(image.imageName.image).isEqualTo("image")
+        assertThat(image.imageName.tag).isNullOrEmpty()
+        assertThat(image.imageName.digest).isNullOrEmpty()
+    }
+
+    @Test
+    fun `must output correct image name`() {
+        val image = ContainerImage.ImageName(
+            "repo.io/account/bucket",
+            "image",
+            "v1.2.3",
+            "digest"
+        )
+        assertThat(image.toString()).isEqualTo("repo.io/account/bucket/image:v1.2.3@digest")
+    }
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
@@ -1,0 +1,102 @@
+package org.openrewrite.kubernetes.search
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.kubernetes.KubernetesRecipeTest
+
+class FindDisallowedImageTagsTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must find disallowed image tags`() = assertChanged(
+        recipe = FindDisallowedImageTags(
+            setOf("latest", "dev")
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: repo/app:latest
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+                        initContainers:            
+                        - name: migration
+                          image: repo/migration:latest
+                        - name: backup
+                          image: repo/backup:dev
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: ~~(disallowed tag: [latest, dev])~~>repo/app:latest
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        containers:            
+                        - name: app
+                          image: ~~(disallowed tag: [latest, dev])~~>repo/app:latest
+                        - name: sidecar
+                          image: ~~(disallowed tag: [latest, dev])~~>repo/sidecar:dev
+                        initContainers:            
+                        - name: migration
+                          image: ~~(disallowed tag: [latest, dev])~~>repo/migration:latest
+                        - name: backup
+                          image: ~~(disallowed tag: [latest, dev])~~>repo/backup:dev
+        """
+    )
+
+    @Test
+    fun `must find disallowed image tags in workloads`() = assertChanged(
+        recipe = FindDisallowedImageTags(
+            setOf("latest", "dev")
+        ),
+        before = """
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+              template:
+                spec:
+                  containers:            
+                  - image: nginx:latest
+            ---
+            apiVersion: apps/v1
+            kind: StatefulSet
+            spec:
+              template:
+                spec:
+                  containers:            
+                  - image: app:dev
+        """.trimIndent(),
+        after = """
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+              template:
+                spec:
+                  containers:            
+                  - image: ~~(disallowed tag: [latest, dev])~~>nginx:latest
+            ---
+            apiVersion: apps/v1
+            kind: StatefulSet
+            spec:
+              template:
+                spec:
+                  containers:            
+                  - image: ~~(disallowed tag: [latest, dev])~~>app:dev
+        """.trimIndent()
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
@@ -1,5 +1,19 @@
 package org.openrewrite.kubernetes.search
-
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.junit.jupiter.api.Test
 import org.openrewrite.kubernetes.KubernetesRecipeTest
 


### PR DESCRIPTION
Addresses OPA policy for use of disallowed tags: https://github.com/open-policy-agent/gatekeeper-library/tree/master/library/general/disallowedtags