### PR TITLE
Recipes to find and upgrade container image names

### DIFF
--- a/src/main/java/org/openrewrite/kubernetes/ContainerImage.java
+++ b/src/main/java/org/openrewrite/kubernetes/ContainerImage.java
@@ -17,6 +17,9 @@ package org.openrewrite.kubernetes;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.Cursor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.yaml.XPathMatcher;
 import org.openrewrite.yaml.tree.Yaml;
 
 import static org.openrewrite.internal.StringUtils.isNullOrEmpty;
@@ -58,12 +61,26 @@ public class ContainerImage {
         this.imageName = new ImageName(repository, image, tag, digest);
     }
 
+    public static boolean matches(Cursor cursor) {
+        if (!(cursor.getValue() instanceof Yaml.Scalar)) {
+            return false;
+        }
+        XPathMatcher imageMatcher = new XPathMatcher("//spec/containers/image");
+        XPathMatcher initImageMatcher = new XPathMatcher("//spec/initContainers/image");
+        Cursor parent = cursor.getParentOrThrow();
+        return imageMatcher.matches(parent) || initImageMatcher.matches(parent);
+    }
+
     @Value
     public static class ImageName {
 
+        @Nullable
         String repository;
+        @Nullable
         String image;
+        @Nullable
         String tag;
+        @Nullable
         String digest;
 
         @Override

--- a/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
@@ -37,6 +37,12 @@ public class FindDisallowedImageTags extends Recipe {
             example = "latest")
     Set<String> disallowedTags;
 
+    @Option(displayName = "Include initContainers",
+            description = "Boolean to indicate whether or not to treat initContainers/image identically to " +
+                    "containers/image.",
+            example = "false")
+    boolean includeInitContainers;
+
     @Override
     public String getDisplayName() {
         return "Disallowed tags";
@@ -52,7 +58,7 @@ public class FindDisallowedImageTags extends Recipe {
         return new YamlIsoVisitor<ExecutionContext>() {
             @Override
             public Yaml.Scalar visitScalar(Yaml.Scalar scalar, ExecutionContext executionContext) {
-                if (ContainerImage.matches(getCursor())) {
+                if (ContainerImage.matches(getCursor(), includeInitContainers)) {
                     ContainerImage image = new ContainerImage(scalar);
                     if (disallowedTags.stream().anyMatch(t -> t.equals(image.getImageName().getTag()))) {
                         return scalar.withMarkers(scalar.getMarkers().addIfAbsent(new YamlSearchResult(

--- a/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindDisallowedImageTags.java
@@ -17,9 +17,11 @@ package org.openrewrite.kubernetes.search;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.kubernetes.ContainerImage;
-import org.openrewrite.yaml.XPathMatcher;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.search.YamlSearchResult;
 import org.openrewrite.yaml.tree.Yaml;
@@ -47,14 +49,10 @@ public class FindDisallowedImageTags extends Recipe {
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
-        XPathMatcher imageMatcher = new XPathMatcher("//spec/containers/image");
-        XPathMatcher initImageMatcher = new XPathMatcher("//spec/initContainers/image");
-
         return new YamlIsoVisitor<ExecutionContext>() {
             @Override
             public Yaml.Scalar visitScalar(Yaml.Scalar scalar, ExecutionContext executionContext) {
-                Cursor parent = getCursor().getParentOrThrow();
-                if (imageMatcher.matches(parent) || initImageMatcher.matches(parent)) {
+                if (ContainerImage.matches(getCursor())) {
                     ContainerImage image = new ContainerImage(scalar);
                     if (disallowedTags.stream().anyMatch(t -> t.equals(image.getImageName().getTag()))) {
                         return scalar.withMarkers(scalar.getMarkers().addIfAbsent(new YamlSearchResult(

--- a/src/main/java/org/openrewrite/kubernetes/search/FindImage.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindImage.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.kubernetes.ContainerImage;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.search.YamlSearchResult;
+import org.openrewrite.yaml.tree.Yaml;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindImage extends Recipe {
+
+    @Option(displayName = "Repository",
+            description = "The repository part of the image name to search for in containers and initContainers.",
+            example = "gcr.io",
+            required = false)
+    @Nullable
+    String repository;
+
+    @Option(displayName = "Image name",
+            description = "The image name to search for in containers and initContainers.",
+            example = "nginx")
+    String imageName;
+
+    @Option(displayName = "Image tag",
+            description = "The tag part of the image name to search for in containers and initContainers.",
+            example = "v1.2.3",
+            required = false)
+    @Nullable
+    String imageTag;
+
+    @Option(displayName = "Image digest",
+            description = "The digest part of the image name to search for in containers and initContainers.",
+            example = "95743679f67454e4f25c287c5c098120b55b9596",
+            required = false)
+    @Nullable
+    String imageDigest;
+
+    @Override
+    public String getDisplayName() {
+        return "Image name";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The image name to search for in containers and initContainers.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        ContainerImage.ImageName imageToSearch = new ContainerImage.ImageName(repository, imageName, imageTag, imageDigest);
+        YamlSearchResult result = new YamlSearchResult(this, imageToSearch.toString());
+
+        return new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Scalar visitScalar(Yaml.Scalar scalar, ExecutionContext executionContext) {
+                if (ContainerImage.matches(getCursor())) {
+                    ContainerImage image = new ContainerImage(scalar);
+                    if (matches(image.getImageName(), imageToSearch)) {
+                        return scalar.withMarkers(scalar.getMarkers().addIfAbsent(result));
+                    }
+                }
+                return super.visitScalar(scalar, executionContext);
+            }
+        };
+    }
+
+    private static boolean matches(ContainerImage.ImageName imageName,
+                                   ContainerImage.ImageName imageToSearch) {
+        boolean matchesRepo =
+                bothNull(imageName.getRepository(), imageToSearch.getRepository())
+                        || firstContainsSecond(imageName.getRepository(), imageToSearch.getRepository())
+                        || isGlobPattern(imageToSearch.getRepository());
+        boolean matchesImage =
+                bothNull(imageName.getImage(), imageToSearch.getImage())
+                        || firstContainsSecond(imageName.getImage(), imageToSearch.getImage())
+                        || isGlobPattern(imageToSearch.getImage());
+        boolean matchesTag =
+                bothNull(imageName.getTag(), imageToSearch.getTag())
+                        || firstContainsSecond(imageName.getTag(), imageToSearch.getTag())
+                        || isGlobPattern(imageToSearch.getTag());
+        boolean matchesDigest =
+                bothNull(imageName.getDigest(), imageToSearch.getDigest())
+                        || firstContainsSecond(imageName.getDigest(), imageToSearch.getDigest())
+                        || isGlobPattern(imageToSearch.getDigest());
+
+        return matchesRepo && matchesImage && matchesTag && matchesDigest;
+    }
+
+    private static boolean bothNull(@Nullable String s1, @Nullable String s2) {
+        return s1 == null && s2 == null;
+    }
+
+    private static boolean firstContainsSecond(@Nullable String s1, @Nullable String s2) {
+        return s1 != null && s2 != null && s1.contains(s2);
+    }
+
+    private static boolean isGlobPattern(@Nullable String s) {
+        return s != null && s.equals("*");
+    }
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/UpdateContainerImageNameTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/UpdateContainerImageNameTest.kt
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openrewrite.kubernetes;
+
+import org.junit.jupiter.api.Test
+
+class UpdateContainerImageNameTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must update container image with all values`() = assertChanged(
+        recipe = UpdateContainerImageName(
+            null,
+            "nginx",
+            null,
+            "gcr.io/myaccount/myrepo",
+            "nginx-custom",
+            "latest",
+            false
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: nginx
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/myrepo/nginx
+                initContainers:             
+                - image: gcr.io/myaccount/myrepo/myinit:latest
+        """.trimIndent(),
+        after = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/myrepo/nginx-custom:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/myrepo/nginx
+                initContainers:             
+                - image: gcr.io/myaccount/myrepo/myinit:latest
+        """.trimIndent()
+    )
+
+    @Test
+    fun `must update container image with partial values`() = assertChanged(
+        recipe = UpdateContainerImageName(
+            null,
+            "nginx*",
+            null,
+            "gcr.io/myaccount/myrepo",
+            null,
+            null,
+            true
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: nginx
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: nginx-custom
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/mydevrepo/nginx-custom:v2
+                initContainers:             
+                - image: gcr.io/myaccount/myrepo/myinit:latest
+        """.trimIndent(),
+        after = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/myrepo/nginx
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/myrepo/nginx-custom
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: gcr.io/myaccount/mydevrepo/nginx-custom:v2
+                initContainers:             
+                - image: gcr.io/myaccount/myrepo/myinit:latest
+        """.trimIndent()
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
@@ -37,7 +37,8 @@ class FindDisallowedImageTagsTest : KubernetesRecipeTest {
     @Test
     fun `must find disallowed image tags`() = assertChanged(
         recipe = FindDisallowedImageTags(
-            setOf("latest", "dev")
+            setOf("latest", "dev"),
+            true
         ),
         before = """
             apiVersion: v1
@@ -90,7 +91,8 @@ class FindDisallowedImageTagsTest : KubernetesRecipeTest {
     @Test
     fun `must find disallowed image tags in workloads`() = assertChanged(
         recipe = FindDisallowedImageTags(
-            setOf("latest", "dev")
+            setOf("latest", "dev"),
+            false
         ),
         before = """
             apiVersion: apps/v1

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
@@ -1,4 +1,3 @@
-package org.openrewrite.kubernetes.search
 /*
  * Copyright 2021 the original author or authors.
  * <p>
@@ -14,6 +13,8 @@ package org.openrewrite.kubernetes.search
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.openrewrite.kubernetes.search
+
 import org.junit.jupiter.api.Test
 import org.openrewrite.kubernetes.KubernetesRecipeTest
 

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.kt
@@ -14,7 +14,21 @@
  * limitations under the License.
  */
 package org.openrewrite.kubernetes.search
-
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.junit.jupiter.api.Test
 import org.openrewrite.kubernetes.KubernetesRecipeTest
 

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindImageTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindImageTest.kt
@@ -1,0 +1,128 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.kubernetes.KubernetesRecipeTest
+
+class FindImageTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must find fully specified image`() = assertChanged(
+        recipe = FindImage(
+            "repo.id/account/bucket",
+            "image",
+            "v1.2.3",
+            "digest"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: image
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: app:v1.2.3
+                initContainers:             
+                - image: account/image:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: repo.id/account/bucket/image:v1.2.3@digest
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: image
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: app:v1.2.3
+                initContainers:             
+                - image: account/image:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: ~~(repo.id/account/bucket/image:v1.2.3@digest)~~>repo.id/account/bucket/image:v1.2.3@digest
+        """
+    )
+
+    @Test
+    fun `must find partly specified image`() = assertChanged(
+        recipe = FindImage(
+            "*",
+            "image",
+            "latest",
+            null
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: image:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: app:v1.2.3
+                initContainers:             
+                - image: account/image:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: repo.id/account/bucket/image:v1.2.3@digest
+        """,
+        after = """
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: ~~(*/image:latest)~~>image:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: app:v1.2.3
+                initContainers:             
+                - image: ~~(*/image:latest)~~>account/image:latest
+            ---
+            apiVersion: v1
+            kind: Pod
+            spec:
+                containers:             
+                - image: repo.id/account/bucket/image:v1.2.3@digest
+        """
+    )
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindImageTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindImageTest.kt
@@ -26,7 +26,8 @@ class FindImageTest : KubernetesRecipeTest {
         recipe = FindImage(
             "repo.id/account/bucket",
             "image",
-            "v1.2.3"
+            "v1.2.3",
+            false
         ),
         before = """
             apiVersion: v1
@@ -71,12 +72,14 @@ class FindImageTest : KubernetesRecipeTest {
                 - image: ~~(repo.id/account/bucket/image:v1.2.3)~~>repo.id/account/bucket/image:v1.2.3@digest
         """
     )
+
     @Test
     fun `must support globbing in image name`() = assertChanged(
         recipe = FindImage(
             "repo.id/*",
             "image",
-            "v1.*"
+            "v1.*",
+            false
         ),
         before = """
             apiVersion: v1
@@ -126,15 +129,16 @@ class FindImageTest : KubernetesRecipeTest {
     fun `must find partly specified image`() = assertChanged(
         recipe = FindImage(
             "*",
-            "image",
-            "latest"
+            "nginx",
+            "latest",
+            false
         ),
         before = """
             apiVersion: v1
             kind: Pod
             spec:
                 containers:             
-                - image: image:latest
+                - image: nginx:latest
             ---
             apiVersion: v1
             kind: Pod
@@ -142,20 +146,20 @@ class FindImageTest : KubernetesRecipeTest {
                 containers:             
                 - image: app:v1.2.3
                 initContainers:             
-                - image: account/image:latest
+                - image: account/nginx:latest
             ---
             apiVersion: v1
             kind: Pod
             spec:
                 containers:             
-                - image: repo.id/account/bucket/image:v1.2.3@digest
+                - image: repo.id/account/bucket/nginx:v1.2.3@digest
         """,
         after = """
             apiVersion: v1
             kind: Pod
             spec:
                 containers:             
-                - image: ~~(*/image:latest)~~>image:latest
+                - image: ~~(*/nginx:latest)~~>nginx:latest
             ---
             apiVersion: v1
             kind: Pod
@@ -163,13 +167,13 @@ class FindImageTest : KubernetesRecipeTest {
                 containers:             
                 - image: app:v1.2.3
                 initContainers:             
-                - image: ~~(*/image:latest)~~>account/image:latest
+                - image: account/nginx:latest
             ---
             apiVersion: v1
             kind: Pod
             spec:
                 containers:             
-                - image: repo.id/account/bucket/image:v1.2.3@digest
+                - image: repo.id/account/bucket/nginx:v1.2.3@digest
         """
     )
 
@@ -178,7 +182,8 @@ class FindImageTest : KubernetesRecipeTest {
         recipe = FindImage(
             "*",
             "*",
-            "*"
+            "*",
+            true
         ),
         before = """
             apiVersion: v1


### PR DESCRIPTION
Implement a find and upgrade recipe for finding container images by specifying a partial string which the image part must contain (i.e. `gcr.io` will match `gcr.io/account/repo`) or a glob pattern to express anything (`*`).