### PR TITLE
Find annotations by presence and value

### DIFF
--- a/src/main/java/org/openrewrite/kubernetes/search/FindAnnotation.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindAnnotation.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.yaml.search.YamlSearchResult;
+import org.openrewrite.yaml.tree.Yaml;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindAnnotation extends Recipe {
+
+    @Option(displayName = "Annotation name",
+            description = "The name of the annotation to search for the existence of.",
+            example = "mycompany.io/annotation")
+    String annotationName;
+    @Option(displayName = "Value regex",
+            description = "An optional regex that will find values that match.",
+            example = "value.*",
+            required = false)
+    @Nullable
+    String valueRegex;
+
+    @Override
+    public String getDisplayName() {
+        return "Find annotation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find annotations that optionally match a given regex.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        YamlSearchResult found = new YamlSearchResult(this, "found:" + annotationName);
+        YamlSearchResult valid = new YamlSearchResult(this, "found:" + valueRegex);
+
+        return new ValidatingMappingEntryVisitor("//metadata/annotations", annotationName, valueRegex) {
+            @Override
+            public Yaml.Mapping.Entry visitFoundEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
+                parent.putMessageOnFirstEnclosing(Yaml.Mapping.Entry.class, MESSAGE_KEY, found);
+                return entry;
+            }
+
+            @Override
+            public Yaml.Mapping.Entry visitValidEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
+                parent.putMessageOnFirstEnclosing(Yaml.Mapping.Entry.class, MESSAGE_KEY, valid);
+                return super.visitInvalidEntry(entry, parent, ctx);
+            }
+        };
+    }
+
+}

--- a/src/main/java/org/openrewrite/kubernetes/search/FindAnnotation.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindAnnotation.java
@@ -31,12 +31,13 @@ public class FindAnnotation extends Recipe {
             description = "The name of the annotation to search for the existence of.",
             example = "mycompany.io/annotation")
     String annotationName;
-    @Option(displayName = "Value regex",
-            description = "An optional regex that will find values that match.",
+
+    @Option(displayName = "Value",
+            description = "An optional glob expression that will find values that match.",
             example = "value.*",
             required = false)
     @Nullable
-    String valueRegex;
+    String value;
 
     @Override
     public String getDisplayName() {
@@ -51,9 +52,9 @@ public class FindAnnotation extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
         YamlSearchResult found = new YamlSearchResult(this, "found:" + annotationName);
-        YamlSearchResult valid = new YamlSearchResult(this, "found:" + valueRegex);
+        YamlSearchResult valid = new YamlSearchResult(this, "found:" + value);
 
-        return new ValidatingMappingEntryVisitor("//metadata/annotations", annotationName, valueRegex) {
+        return new ValidatingMappingEntryVisitor("//metadata/annotations", annotationName, value) {
             @Override
             public Yaml.Mapping.Entry visitFoundEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
                 parent.putMessageOnFirstEnclosing(Yaml.Mapping.Entry.class, MESSAGE_KEY, found);

--- a/src/main/java/org/openrewrite/kubernetes/search/FindMissingAnnotation.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindMissingAnnotation.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.yaml.search.YamlSearchResult;
+import org.openrewrite.yaml.tree.Yaml;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindMissingAnnotation extends Recipe {
+
+    private static final String FIND_ANNO = "find_anno";
+
+    @Option(displayName = "Annotation name",
+            description = "The name of the annotation to search for the existence of.",
+            example = "mycompany.io/annotation")
+    String annotationName;
+    @Option(displayName = "Value regex",
+            description = "An optional regex that will validate values that match.",
+            example = "value.*",
+            required = false)
+    @Nullable
+    String valueRegex;
+
+    @Override
+    public String getDisplayName() {
+        return "Find annotation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find annotations that optionally match a given regex.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        YamlSearchResult missing = new YamlSearchResult(this, "missing:" + annotationName);
+        YamlSearchResult invalid = null != valueRegex ? new YamlSearchResult(this, "invalid:" + valueRegex) : null;
+
+        return new ValidatingMappingEntryVisitor("//metadata/annotations", annotationName, valueRegex) {
+            @Override
+            public Yaml.Mapping visitMissingEntry(Yaml.Mapping mapping, Cursor cursor, ExecutionContext ctx) {
+                cursor.putMessageOnFirstEnclosing(Yaml.Mapping.Entry.class, MESSAGE_KEY, missing);
+                return mapping;
+            }
+
+            @Override
+            public Yaml.Mapping.Entry visitInvalidEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
+                if (invalid != null) {
+                    parent.putMessageOnFirstEnclosing(Yaml.Mapping.Entry.class, MESSAGE_KEY, invalid);
+                }
+                return entry;
+            }
+        };
+    }
+
+}

--- a/src/main/java/org/openrewrite/kubernetes/search/FindMissingAnnotation.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/FindMissingAnnotation.java
@@ -27,18 +27,17 @@ import org.openrewrite.yaml.tree.Yaml;
 @EqualsAndHashCode(callSuper = true)
 public class FindMissingAnnotation extends Recipe {
 
-    private static final String FIND_ANNO = "find_anno";
-
     @Option(displayName = "Annotation name",
             description = "The name of the annotation to search for the existence of.",
             example = "mycompany.io/annotation")
     String annotationName;
-    @Option(displayName = "Value regex",
-            description = "An optional regex that will validate values that match.",
+
+    @Option(displayName = "Value",
+            description = "An optional glob that will validate values that match.",
             example = "value.*",
             required = false)
     @Nullable
-    String valueRegex;
+    String value;
 
     @Override
     public String getDisplayName() {
@@ -47,15 +46,15 @@ public class FindMissingAnnotation extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Find annotations that optionally match a given regex.";
+        return "Find annotations that optionally match a given value.";
     }
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
         YamlSearchResult missing = new YamlSearchResult(this, "missing:" + annotationName);
-        YamlSearchResult invalid = null != valueRegex ? new YamlSearchResult(this, "invalid:" + valueRegex) : null;
+        YamlSearchResult invalid = null != value ? new YamlSearchResult(this, "invalid:" + value) : null;
 
-        return new ValidatingMappingEntryVisitor("//metadata/annotations", annotationName, valueRegex) {
+        return new ValidatingMappingEntryVisitor("//metadata/annotations", annotationName, value) {
             @Override
             public Yaml.Mapping visitMissingEntry(Yaml.Mapping mapping, Cursor cursor, ExecutionContext ctx) {
                 cursor.putMessageOnFirstEnclosing(Yaml.Mapping.Entry.class, MESSAGE_KEY, missing);

--- a/src/main/java/org/openrewrite/kubernetes/search/ValidatingMappingEntryVisitor.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/ValidatingMappingEntryVisitor.java
@@ -36,13 +36,13 @@ class ValidatingMappingEntryVisitor extends YamlIsoVisitor<ExecutionContext> {
     static final String MESSAGE_KEY = ValidatingMappingEntryVisitor.class.getSimpleName();
 
     XPathMatcher mappingMatcher;
-    String annotationName;
+    String entryKey;
     @Nullable
     Pattern validationPattern;
 
-    public ValidatingMappingEntryVisitor(String mappingPath, String annotationName, @Nullable String validationRegex) {
+    public ValidatingMappingEntryVisitor(String mappingPath, String entryKey, @Nullable String validationRegex) {
         this.mappingMatcher = new XPathMatcher(mappingPath);
-        this.annotationName = annotationName;
+        this.entryKey = entryKey;
         this.validationPattern = validationRegex == null ? null : Pattern.compile(validationRegex);
     }
 
@@ -80,12 +80,12 @@ class ValidatingMappingEntryVisitor extends YamlIsoVisitor<ExecutionContext> {
             return m;
         }
 
-        AtomicBoolean annotationFound = new AtomicBoolean(false);
+        AtomicBoolean entryFound = new AtomicBoolean(false);
         List<Yaml.Mapping.Entry> newEntries = ListUtils.map(m.getEntries(), e -> {
-            if (!e.getKey().getValue().equals(annotationName)) {
+            if (!e.getKey().getValue().equals(entryKey)) {
                 return e;
             }
-            annotationFound.compareAndSet(false, true);
+            entryFound.compareAndSet(false, true);
             String annoValue = ((Yaml.Scalar) e.getValue()).getValue();
             if (validationPattern == null) {
                 return visitFoundEntry(e, getCursor(), ctx);
@@ -96,7 +96,7 @@ class ValidatingMappingEntryVisitor extends YamlIsoVisitor<ExecutionContext> {
             }
         });
 
-        if (!annotationFound.get()) {
+        if (!entryFound.get()) {
             m = visitMissingEntry(m, getCursor(), ctx);
         }
 

--- a/src/main/java/org/openrewrite/kubernetes/search/ValidatingMappingEntryVisitor.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/ValidatingMappingEntryVisitor.java
@@ -37,6 +37,7 @@ class ValidatingMappingEntryVisitor extends YamlIsoVisitor<ExecutionContext> {
 
     XPathMatcher mappingMatcher;
     String entryKey;
+
     @Nullable
     Pattern validationPattern;
 

--- a/src/main/java/org/openrewrite/kubernetes/search/ValidatingMappingEntryVisitor.java
+++ b/src/main/java/org/openrewrite/kubernetes/search/ValidatingMappingEntryVisitor.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search;
+
+import lombok.EqualsAndHashCode;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.yaml.XPathMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.search.YamlSearchResult;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+@EqualsAndHashCode(callSuper = true)
+class ValidatingMappingEntryVisitor extends YamlIsoVisitor<ExecutionContext> {
+
+    static final String MESSAGE_KEY = ValidatingMappingEntryVisitor.class.getSimpleName();
+
+    XPathMatcher mappingMatcher;
+    String annotationName;
+    @Nullable
+    Pattern validationPattern;
+
+    public ValidatingMappingEntryVisitor(String mappingPath, String annotationName, @Nullable String validationRegex) {
+        this.mappingMatcher = new XPathMatcher(mappingPath);
+        this.annotationName = annotationName;
+        this.validationPattern = validationRegex == null ? null : Pattern.compile(validationRegex);
+    }
+
+    public Yaml.Mapping visitMissingEntry(Yaml.Mapping mapping, Cursor cursor, ExecutionContext ctx) {
+        return mapping;
+    }
+
+    public Yaml.Mapping.Entry visitInvalidEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
+        return entry;
+    }
+
+    public Yaml.Mapping.Entry visitFoundEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
+        return entry;
+    }
+
+    public Yaml.Mapping.Entry visitValidEntry(Yaml.Mapping.Entry entry, Cursor parent, ExecutionContext ctx) {
+        return entry;
+    }
+
+    @Override
+    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+        Yaml.Mapping.Entry e = super.visitMappingEntry(entry, ctx);
+        YamlSearchResult r = getCursor().getMessage(MESSAGE_KEY);
+        if (r != null) {
+            return e.withMarkers(e.getMarkers().addIfAbsent(r));
+        }
+        return e;
+    }
+
+    @Override
+    public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
+        Yaml.Mapping m = super.visitMapping(mapping, ctx);
+        Cursor parent = getCursor().getParentOrThrow();
+        if (!mappingMatcher.matches(parent)) {
+            return m;
+        }
+
+        AtomicBoolean annotationFound = new AtomicBoolean(false);
+        List<Yaml.Mapping.Entry> newEntries = ListUtils.map(m.getEntries(), e -> {
+            if (!e.getKey().getValue().equals(annotationName)) {
+                return e;
+            }
+            annotationFound.compareAndSet(false, true);
+            String annoValue = ((Yaml.Scalar) e.getValue()).getValue();
+            if (validationPattern == null) {
+                return visitFoundEntry(e, getCursor(), ctx);
+            } else if (validationPattern.matcher(annoValue).matches()) {
+                return visitValidEntry(e, getCursor(), ctx);
+            } else {
+                return visitInvalidEntry(e, getCursor(), ctx);
+            }
+        });
+
+        if (!annotationFound.get()) {
+            m = visitMissingEntry(m, getCursor(), ctx);
+        }
+
+        return m.withEntries(newEntries);
+    }
+
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindAnnotationTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindAnnotationTest.kt
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.kubernetes.KubernetesRecipeTest
+
+class FindAnnotationTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must find if annotation exists`() = assertChanged(
+        recipe = FindAnnotation(
+            "mycompany.io/annotation",
+            null
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              annotations:
+                mycompany.io/annotation: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              annotations:
+                mycompany.io/annotation: "novalue"
+        """.trimIndent(),
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              ~~(found:mycompany.io/annotation)~~>annotations:
+                mycompany.io/annotation: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              ~~(found:mycompany.io/annotation)~~>annotations:
+                mycompany.io/annotation: "novalue"
+        """.trimIndent()
+    )
+
+    @Test
+    fun `must find by annotation value`() = assertChanged(
+        recipe = FindAnnotation(
+            "mycompany.io/annotation",
+            "has(.*)"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              annotations:
+                mycompany.io/annotation: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              annotations:
+                mycompany.io/annotation: "novalue"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        metadata:
+                            annotations:
+                                mycompany.io/annotation: "hasvalue"
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+        """.trimIndent(),
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              ~~(found:has(.*))~~>annotations:
+                mycompany.io/annotation: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              annotations:
+                mycompany.io/annotation: "novalue"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        metadata:
+                            ~~(found:has(.*))~~>annotations:
+                                mycompany.io/annotation: "hasvalue"
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+        """.trimIndent()
+    )
+}

--- a/src/test/kotlin/org/openrewrite/kubernetes/search/FindMissingAnnotationTest.kt
+++ b/src/test/kotlin/org/openrewrite/kubernetes/search/FindMissingAnnotationTest.kt
@@ -1,0 +1,156 @@
+/*
+ *  Copyright 2021 the original author or authors.
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openrewrite.kubernetes.search
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.kubernetes.KubernetesRecipeTest
+
+class FindMissingAnnotationTest : KubernetesRecipeTest {
+
+    @Test
+    fun `must find missing annotation`() = assertChanged(
+        recipe = FindMissingAnnotation(
+            "mycompany.io/annotation",
+            null
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              annotations:
+                mycompany.io/something: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              annotations:
+                mycompany.io/annotation: "novalue"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        metadata:
+                            annotations:
+                                mycompany.io/something: "hasvalue"
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+        """.trimIndent(),
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              ~~(missing:mycompany.io/annotation)~~>annotations:
+                mycompany.io/something: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              annotations:
+                mycompany.io/annotation: "novalue"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        metadata:
+                            ~~(missing:mycompany.io/annotation)~~>annotations:
+                                mycompany.io/something: "hasvalue"
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+        """.trimIndent()
+    )
+
+    @Test
+    fun `must find invalid annotation`() = assertChanged(
+        recipe = FindMissingAnnotation(
+            "mycompany.io/annotation",
+            "has(.*)"
+        ),
+        before = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              annotations:
+                mycompany.io/annotation: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              annotations:
+                mycompany.io/annotation: "novalue"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        metadata:
+                            annotations:
+                                mycompany.io/annotation: "hasvalue"
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+        """.trimIndent(),
+        after = """
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod1
+              annotations:
+                mycompany.io/annotation: "hasvalue"
+            ---
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: mypod2
+              ~~(invalid:has(.*))~~>annotations:
+                mycompany.io/annotation: "novalue"
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+                template:
+                    spec:
+                        metadata:
+                            annotations:
+                                mycompany.io/annotation: "hasvalue"
+                        containers:            
+                        - name: app
+                          image: repo/app:latest
+                        - name: sidecar
+                          image: repo/sidecar:dev
+        """.trimIndent()
+    )
+
+}


### PR DESCRIPTION
These recipes find an annotation by presence if no regex is specified, or by regex pattern if one is. The `FindMissingAnnotation` recipe is the inverse: it will find instances of the annotation not present or not matching the regex.