### PR TITLE
Have test classes extend abstract class KubernetesRecipeTest

### DIFF
--- a/src/test/java/org/openrewrite/kubernetes/AddConfigurationTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/AddConfigurationTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class AddConfigurationTest extends KubernetesParserTest {
+class AddConfigurationTest extends KubernetesRecipeTest {
 
     @Test
     void addConfigurationToMappingEntryIfThePathDoesNotExist() {

--- a/src/test/java/org/openrewrite/kubernetes/KubernetesRecipeTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/KubernetesRecipeTest.java
@@ -20,7 +20,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.yaml.tree.Yaml;
 
-class KubernetesRecipeTest implements RewriteTest {
+public abstract class KubernetesRecipeTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(KubernetesParser.builder());

--- a/src/test/java/org/openrewrite/kubernetes/UpdateContainerImageNameTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/UpdateContainerImageNameTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class UpdateContainerImageNameTest extends KubernetesParserTest {
+class UpdateContainerImageNameTest extends KubernetesRecipeTest {
 
     @Test
     void updateContainerImageWithAllValues() {

--- a/src/test/java/org/openrewrite/kubernetes/rbac/AddRuleToRoleTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/rbac/AddRuleToRoleTest.java
@@ -16,13 +16,13 @@
 package org.openrewrite.kubernetes.rbac;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import java.util.Set;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class AddRuleToRoleTest extends KubernetesParserTest {
+class AddRuleToRoleTest extends KubernetesRecipeTest {
 
     @Test
     void unsupportedApiVersion() {

--- a/src/test/java/org/openrewrite/kubernetes/resource/CapResourceLimitToMaximumTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/resource/CapResourceLimitToMaximumTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.resource;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class CapResourceLimitToMaximumTest extends KubernetesParserTest {
+class CapResourceLimitToMaximumTest extends KubernetesRecipeTest {
 
     @Test
     void capResourceLimitToGivenMaximumInDifferentUnits() {

--- a/src/test/java/org/openrewrite/kubernetes/resource/FindExceedsResourceLimitTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/resource/FindExceedsResourceLimitTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.resource;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindExceedsResourceLimitTest extends KubernetesParserTest {
+class FindExceedsResourceLimitTest extends KubernetesRecipeTest {
 
     @Test
     void findLimitsThatExceedAGivenMaximum() {

--- a/src/test/java/org/openrewrite/kubernetes/resource/FindExceedsResourceRatioTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/resource/FindExceedsResourceRatioTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.resource;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindExceedsResourceRatioTest extends KubernetesParserTest {
+class FindExceedsResourceRatioTest extends KubernetesRecipeTest {
 
     @Test
     void findLimitsThatExceedAGivenMaximumRatio() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindAnnotationTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindAnnotationTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindAnnotationTest extends KubernetesParserTest {
+class FindAnnotationTest extends KubernetesRecipeTest {
 
     @Test
     void findIfAnnotationExists() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindDisallowedImageTagsTest.java
@@ -17,13 +17,13 @@ package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import java.util.Set;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindDisallowedImageTagsTest extends KubernetesParserTest {
+class FindDisallowedImageTagsTest extends KubernetesRecipeTest {
 
     @Disabled("JsonPathMatcher has changed, need to figure out how to fix this.")
     @Test

--- a/src/test/java/org/openrewrite/kubernetes/search/FindImageTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindImageTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindImageTest extends KubernetesParserTest {
+class FindImageTest extends KubernetesRecipeTest {
 
     @Test
     void findFullySpecifiedImage() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindMissingDigestTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindMissingDigestTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindMissingDigestTest extends KubernetesParserTest {
+class FindMissingDigestTest extends KubernetesRecipeTest {
 
     @Test
     void detectWhenDigestIsMissing() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindMissingOrInvalidAnnotationTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindMissingOrInvalidAnnotationTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindMissingOrInvalidAnnotationTest extends KubernetesParserTest {
+class FindMissingOrInvalidAnnotationTest extends KubernetesRecipeTest {
 
     @Test
     void findMissingAnnotation() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindMissingOrInvalidLabelTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindMissingOrInvalidLabelTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindMissingOrInvalidLabelTest extends KubernetesParserTest {
+class FindMissingOrInvalidLabelTest extends KubernetesRecipeTest {
 
     @Test
     void findMissingLabel() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindNonTlsIngressTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindNonTlsIngressTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindNonTlsIngressTest extends KubernetesParserTest {
+class FindNonTlsIngressTest extends KubernetesRecipeTest {
 
     @Test
     void findIngressWithNoTLSConfigured() {

--- a/src/test/java/org/openrewrite/kubernetes/search/FindResourceMissingConfigurationTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/search/FindResourceMissingConfigurationTest.java
@@ -17,11 +17,11 @@ package org.openrewrite.kubernetes.search;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.Environment;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindResourceMissingConfigurationTest extends KubernetesParserTest {
+class FindResourceMissingConfigurationTest extends KubernetesRecipeTest {
 
     @Test
     void podLivenessProbe() {

--- a/src/test/java/org/openrewrite/kubernetes/services/FindServiceExternalIPTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/services/FindServiceExternalIPTest.java
@@ -16,13 +16,13 @@
 package org.openrewrite.kubernetes.services;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import java.util.Set;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindServiceExternalIPTest extends KubernetesParserTest {
+class FindServiceExternalIPTest extends KubernetesRecipeTest {
 
     @Test
     void findServicesByExternalIPs() {

--- a/src/test/java/org/openrewrite/kubernetes/services/FindServicesByTypeTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/services/FindServicesByTypeTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.services;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class FindServicesByTypeTest extends KubernetesParserTest {
+class FindServicesByTypeTest extends KubernetesRecipeTest {
 
     @Test
     void findNodePortServices() {

--- a/src/test/java/org/openrewrite/kubernetes/services/UpdateServiceExternalIPTest.java
+++ b/src/test/java/org/openrewrite/kubernetes/services/UpdateServiceExternalIPTest.java
@@ -16,11 +16,11 @@
 package org.openrewrite.kubernetes.services;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.kubernetes.KubernetesParserTest;
+import org.openrewrite.kubernetes.KubernetesRecipeTest;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 
-class UpdateServiceExternalIPTest extends KubernetesParserTest {
+class UpdateServiceExternalIPTest extends KubernetesRecipeTest {
 
 
     @Test


### PR DESCRIPTION
Since otherwise JUnit best practices keeps removing public modifier